### PR TITLE
Ruby: 2.3.8 -> 2.6

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run all specs
 
     container:
-      image: ruby:2.3.8-stretch
+      image: ruby:2.6.5-stretch
 
     steps:
       - name: Clone repository

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -8,7 +8,7 @@ jobs:
     name: Run all specs
 
     container:
-      image: ruby:2.6.5-stretch
+      image: ruby:2.6.5-buster
 
     steps:
       - name: Clone repository

--- a/docker-spec/Dockerfile
+++ b/docker-spec/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5-stretch
+FROM ruby:2.6.5-buster
 
 # -------------
 # Working directory


### PR DESCRIPTION
Hi @nsave 

Running specs in 2.6 shows deprecation warnings: `warning: constant ::Fixnum is deprecated` (you can see these warnings if you click on "show all checks" below in this PR, then "Details" then expand the "Run tests" stage in the new page)

We should switch to `Integer` but then our gem would then require Ruby 2.4+. I was thinking we could live with these warnings for a while, what's your take?

If you agree, feel free to merge into master (I've made you "reviewer" to indicate this)